### PR TITLE
Add useMaterialX argument

### DIFF
--- a/tests/test_use_materialx.py
+++ b/tests/test_use_materialx.py
@@ -1,0 +1,58 @@
+import importlib.util
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+
+# create stub modules for pxr and usdUtils to allow importing the script
+pxr_stub = types.ModuleType('pxr')
+sys.modules.setdefault('pxr', pxr_stub)
+
+usdUtils_stub = types.ModuleType('usdUtils')
+class WrapMode:
+    black = 'black'
+    clamp = 'clamp'
+    repeat = 'repeat'
+    mirror = 'mirror'
+    useMetadata = 'useMetadata'
+
+def isWrapModeCorrect(mode):
+    return True
+
+class Material:
+    def __init__(self, name):
+        self.name = name
+        self.inputs = {}
+    def isEmpty(self):
+        return not self.inputs
+
+usdUtils_stub.WrapMode = WrapMode
+usdUtils_stub.isWrapModeCorrect = isWrapModeCorrect
+usdUtils_stub.Material = Material
+usdUtils_stub.Map = object
+usdUtils_stub.Input = types.SimpleNamespace(names=[], channels=[])
+usdUtils_stub.printError = lambda *a, **k: None
+usdUtils_stub.printWarning = lambda *a, **k: None
+usdUtils_stub.ConvertError = Exception
+usdUtils_stub.ConvertExit = Exception
+sys.modules['usdUtils'] = usdUtils_stub
+
+# load the usdzconvert script as module
+script_path = Path(__file__).resolve().parents[1] / 'usdzconvert' / 'usdzconvert'
+loader = importlib.machinery.SourceFileLoader('usdzconvert_script', str(script_path))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+usdz_module = importlib.util.module_from_spec(spec)
+loader.exec_module(usdz_module)
+
+
+def test_use_materialx_flag():
+    parser = usdz_module.Parser()
+    result = parser.parse(['-useMaterialX', 'cube.glb'])
+    assert result.useMaterialX is True
+    assert result.inFilePath == 'cube.glb'
+
+
+def test_default_materialx_flag():
+    parser = usdz_module.Parser()
+    result = parser.parse(['cube.glb'])
+    assert result.useMaterialX is False

--- a/usdzconvert/usdzconvert
+++ b/usdzconvert/usdzconvert
@@ -60,6 +60,7 @@ class ParserOut:
         self.loop = False
         self.noloop = False
         self.useObjMtl = False
+        self.useMaterialX = False
         material = usdUtils.Material('')
         self.materials.append(material)
 
@@ -71,6 +72,7 @@ class OpenParameters:
         self.searchPaths = None
         self.verbose = False
         self.metersPerUnit = 0 # set by converters
+        self.useMaterialX = False
 
 
 class Parser:
@@ -98,6 +100,7 @@ class Parser:
                    [-copytextures]\n\
                    [-metersPerUnit value]\n\
                    [-useObjMtl]\n\
+                   [-useMaterialX]\n\
                    [-preferredIblVersion value]\n\
                    [-loop]\n\
                    [-no-loop]\n\
@@ -332,6 +335,8 @@ class Parser:
                     self.out.noloop = True
                 elif '-useObjMtl' == argument:
                     self.out.useObjMtl = True
+                elif '-useMaterialX' == argument or '--usematerialx' == argument.lower():
+                    self.out.useMaterialX = True
                 elif '-h' == argument or '--help' == argument:
                     self.printHelpAndExit()
                 elif '-version' == argument or '--version' == argument:
@@ -634,6 +639,7 @@ def process(argumentList):
     openParameters.copyTextures = parserOut.copyTextures and not dstIsUsdz
     openParameters.searchPaths = parserOut.paths
     openParameters.verbose = parserOut.verbose
+    openParameters.useMaterialX = parserOut.useMaterialX
 
     srcIsUsd = False
     srcIsUsdz = False


### PR DESCRIPTION
## Summary
- add `useMaterialX` flag to CLI parser
- pass `useMaterialX` through open parameters
- cover the parser with unit tests using cube.glb

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9a54a2dc832481e6a2844e8deb75