### PR TITLE
Implement useMaterialX flag passthrough

### DIFF
--- a/GLB_USDZ_MATERIALX_DETAIL_ZH.md
+++ b/GLB_USDZ_MATERIALX_DETAIL_ZH.md
@@ -11,7 +11,7 @@
 - 调用 `usdStageWithGlTF` 时，将该开关写入 `OpenParameters` 并一并传递【F:usdzconvert/usdzconvert†L638-L649】。
 
 ## 2. `usdStageWithGlTF` 与 `glTFConverter`
-- `usdStageWithGlTF()` 函数新增 `useMaterialX` 参数，并在创建 `glTFConverter` 时传递【F:usdzconvert/usdStageWithGlTF.py†L1524-L1529】。
+- `usdStageWithGlTF()` 函数新增 `useMaterialX` 参数，并在创建 `glTFConverter` 时传递【F:usdzconvert/usdStageWithGlTF.py†L1525-L1530】。
 - 在 `glTFConverter.__init__()` 中保存此标记，例如 `self.useMaterialX = openParameters.useMaterialX`，以便后续流程判断【F:usdzconvert/usdStageWithGlTF.py†L398-L418】。
 
 ## 3. MaterialX 材质生成

--- a/GLB_USDZ_TEXTURE_CONNECTION_ZH.md
+++ b/GLB_USDZ_TEXTURE_CONNECTION_ZH.md
@@ -4,7 +4,7 @@
 
 ## 1. 基本流程概览
 1. `usdzconvert` 检测到输入扩展名为 `.gltf`/`.glb` 后，导入 `usdStageWithGlTF` 模块并执行 `usdStageWithGlTF()`【F:usdzconvert/usdzconvert†L640-L652】。
-2. 该函数实例化 `glTFConverter`，随后调用 `makeUsdStage()` 构建 `Usd.Stage`【F:usdzconvert/usdStageWithGlTF.py†L1524-L1534】。
+2. 该函数实例化 `glTFConverter`，随后调用 `makeUsdStage()` 构建 `Usd.Stage`【F:usdzconvert/usdStageWithGlTF.py†L1525-L1530】。
 3. `makeUsdStage()` 在内部依次执行 `createMaterials()`、节点和动画处理，最终 `asset.finalize()` 完成 Stage 设置【F:usdzconvert/usdStageWithGlTF.py†L1504-L1523】。
 
 ## 2. 解析 glb 并保存贴图

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ https://developer.apple.com/videos/play/wwdc2019/602/
 
 `usdzconvert` is a Python script that converts obj, gltf, fbx, abc, and usda/usdc/usd assets to usdz.
 It also performs asset validation on the generated usdz.
-For more information, run 
+For more information, run
 
     usdzconvert -h
+
+### MaterialX Support
+
+`usdzconvert` includes an optional `-useMaterialX` switch. When enabled, the
+converter will store a flag in the conversion parameters so that later stages
+can generate MaterialX based shader graphs. The default behaviour continues to
+produce UsdPreviewSurface materials.
 
 ### iOS 12 Compatibility
 

--- a/tests/test_stage_with_gltf.py
+++ b/tests/test_stage_with_gltf.py
@@ -1,0 +1,52 @@
+import importlib.util
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+
+# stub modules for pxr, usdUtils and numpy
+pxr_stub = types.ModuleType('pxr')
+sys.modules.setdefault('pxr', pxr_stub)
+
+usdUtils_stub = types.ModuleType('usdUtils')
+class WrapMode:
+    clamp = 'clamp'
+    mirror = 'mirror'
+    repeat = 'repeat'
+
+class NodeManager:
+    def __init__(self):
+        pass
+
+usdUtils_stub.WrapMode = WrapMode
+usdUtils_stub.NodeManager = NodeManager
+usdUtils_stub.makeValidIdentifier = lambda s: s
+usdUtils_stub.Asset = object
+usdUtils_stub.Skinning = lambda *a, **k: None
+usdUtils_stub.ShapeBlending = lambda *a, **k: types.SimpleNamespace()
+usdUtils_stub.printError = lambda *a, **k: None
+usdUtils_stub.printWarning = lambda *a, **k: None
+sys.modules['usdUtils'] = usdUtils_stub
+
+numpy_stub = types.ModuleType('numpy')
+sys.modules.setdefault('numpy', numpy_stub)
+
+# load usdStageWithGlTF as module
+script_path = Path(__file__).resolve().parents[1] / 'usdzconvert' / 'usdStageWithGlTF.py'
+loader = importlib.machinery.SourceFileLoader('usdStageWithGlTF_script', str(script_path))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+usd_stage_module = importlib.util.module_from_spec(spec)
+loader.exec_module(usd_stage_module)
+
+class DummyConverter:
+    def __init__(self, gltfPath, usdPath, legacyModifier, openParameters, useMaterialX=False):
+        self.flag = useMaterialX
+    def makeUsdStage(self):
+        return self.flag
+
+
+def test_usdstage_passes_flag(monkeypatch):
+    monkeypatch.setattr(usd_stage_module, 'glTFConverter', DummyConverter)
+    openParams = types.SimpleNamespace()
+    result = usd_stage_module.usdStageWithGlTF('cube.glb', 'out.usd', False, openParams, True)
+    assert result is True

--- a/usdzconvert/usdStageWithGlTF.py
+++ b/usdzconvert/usdStageWithGlTF.py
@@ -396,7 +396,7 @@ class Accessor:
 
 
 class glTFConverter:
-    def __init__(self, gltfPath, usdPath, legacyModifier, openParameters):
+    def __init__(self, gltfPath, usdPath, legacyModifier, openParameters, useMaterialX=False):
         self.usdStage = None
         self.buffers = []
         self.gltf = None
@@ -406,6 +406,7 @@ class glTFConverter:
         self.nodeNames = {} # to avoid duplicate node names
         self.copyTextures = openParameters.copyTextures
         self.verbose = openParameters.verbose
+        self.useMaterialX = useMaterialX
         self.legacyModifier = legacyModifier # for iOS 12 compatibility
         self.skeletonByNode = {} # collect skinned mesh to construct later 
         self.blendShapeByNode = {} # collect meshes with blend shapes to construct later 
@@ -1521,10 +1522,10 @@ class glTFConverter:
 
 
 
-def usdStageWithGlTF(gltfPath, usdPath, legacyModifier, openParameters):
+def usdStageWithGlTF(gltfPath, usdPath, legacyModifier, openParameters, useMaterialX=False):
     if usdStageWithGlTFLoaded == False:
         return None
 
-    converter = glTFConverter(gltfPath, usdPath, legacyModifier, openParameters)
+    converter = glTFConverter(gltfPath, usdPath, legacyModifier, openParameters, useMaterialX)
     return converter.makeUsdStage()
 

--- a/usdzconvert/usdzconvert
+++ b/usdzconvert/usdzconvert
@@ -652,7 +652,7 @@ def process(argumentList):
     elif '.gltf' == srcExt or '.glb' == srcExt:
         global usdStageWithGlTF_module
         usdStageWithGlTF_module = importlib.import_module("usdStageWithGlTF")
-        usdStage = usdStageWithGlTF_module.usdStageWithGlTF(srcPath, tmpPath, legacyModifier, openParameters)
+        usdStage = usdStageWithGlTF_module.usdStageWithGlTF(srcPath, tmpPath, legacyModifier, openParameters, parserOut.useMaterialX)
     elif '.fbx' == srcExt:
         global usdStageWithFbx_module
         usdStageWithFbx_module = importlib.import_module("usdStageWithFbx")


### PR DESCRIPTION
## Summary
- propagate `useMaterialX` flag through `usdStageWithGlTF`
- accept flag in `glTFConverter` and store it
- forward the option from `usdzconvert`
- test that the flag reaches the converter
- document MaterialX flag in README
- update line references in design docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d11c5fdfc83249b14a933f8286a24