### PR TITLE
Add MaterialX library packaging

### DIFF
--- a/GLB_USDZ_MATERIALX_DETAIL_ZH.md
+++ b/GLB_USDZ_MATERIALX_DETAIL_ZH.md
@@ -20,7 +20,7 @@
  - `_addMapToUsdMaterial()` 保持旧实现不变，另新增 `_addMapToMaterialX()` 处理 MaterialX 节点的贴图输入，可参考当前实现【F:usdzconvert/usdUtils.py†L498-L559】。
 
 ## 4. 调整材质创建流程
- - `createMaterials()` 在生成 `usdUtils.Material` 后，根据 `self.useMaterialX` 选择调用 `makeUsdMaterialX()` 或 `makeUsdMaterial()`【F:usdzconvert/usdStageWithGlTF.py†L633-L720】。
-- 若启用 MaterialX，打包 `.usdz` 时应同时复制所需的 `.mtlx` 库文件，确保运行时可以解析。
+- `createMaterials()` 在生成 `usdUtils.Material` 后，根据 `self.useMaterialX` 选择调用 `makeUsdMaterialX()` 或 `makeUsdMaterial()`【F:usdzconvert/usdStageWithGlTF.py†L633-L720】。
+- 若启用 MaterialX，打包 `.usdz` 时应同时复制所需的 `.mtlx` 库文件，确保运行时可以解析【F:usdzconvert/usdzconvert†L802-L806】。
 
 通过以上修改，命令行添加 `-useMaterialX` 后即可在转换阶段生成基于 MaterialX 的 `UsdShade.Material` 网络，同时保持旧接口与 UsdPreviewSurface 的兼容。 

--- a/GLB_USDZ_MATERIALX_SUPPORT_ZH.md
+++ b/GLB_USDZ_MATERIALX_SUPPORT_ZH.md
@@ -19,7 +19,7 @@
    - 创建 `UsdShade.Material` 实例。
    - 调用 `_createMaterialXShader()` 生成 `nd_standard_surface` 节点，并根据贴图或常量输入连接相关端口（如 `base_color`, `metalness`, `roughness`）。
    - 将生成的 `materialXShader` 的 `out` 输出连接到 `surface`。
-4. **材质库依赖**：打包 usdz 时将所需的 MaterialX `.mtlx` 库文件一并复制到包内，以便运行时解析。
+4. **材质库依赖**：打包 usdz 时将所需的 MaterialX `.mtlx` 库文件一并复制到包内，以便运行时解析【F:usdzconvert/usdzconvert†L802-L806】。
 5. **向后兼容**：若目标查看器不支持 MaterialX，可在命令行关闭该功能，或在生成的 USD 中同时保留 PreviewSurface 供回退使用。
 
 ## 3. 后续工作

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ For more information, run
 `usdzconvert` includes an optional `-useMaterialX` switch. When enabled, the
 converter will store a flag in the conversion parameters so that later stages
 can generate MaterialX based shader graphs. The default behaviour continues to
-produce UsdPreviewSurface materials.
+produce UsdPreviewSurface materials. When generating a `.usdz` with this option,
+any `.mtlx` library files found in paths listed by the `MATERIALX_LIB_PATHS`
+environment variable are copied into the package.
 
 ### iOS 12 Compatibility
 

--- a/tests/test_copy_mtlx_files.py
+++ b/tests/test_copy_mtlx_files.py
@@ -1,0 +1,50 @@
+import importlib.util
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+import os
+
+# stub modules for pxr and usdUtils
+pxr_stub = types.ModuleType('pxr')
+sys.modules.setdefault('pxr', pxr_stub)
+
+usdUtils_stub = types.ModuleType('usdUtils')
+
+def copy(src, dst, verbose=False):
+    Path(dst).write_bytes(Path(src).read_bytes())
+
+usdUtils_stub.copy = copy
+usdUtils_stub.Material = lambda name: types.SimpleNamespace(inputs={}, isEmpty=lambda:True)
+usdUtils_stub.Input = types.SimpleNamespace(names=[], channels=[])
+usdUtils_stub.WrapMode = types.SimpleNamespace(useMetadata='useMetadata')
+usdUtils_stub.NodeManager = lambda: None
+usdUtils_stub.printError = lambda *a, **k: None
+usdUtils_stub.printWarning = lambda *a, **k: None
+sys.modules['usdUtils'] = usdUtils_stub
+
+# load usdzconvert module
+script_path = Path(__file__).resolve().parents[1] / 'usdzconvert' / 'usdzconvert'
+loader = importlib.machinery.SourceFileLoader('usdzconvert_script', str(script_path))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+usdz_module = importlib.util.module_from_spec(spec)
+loader.exec_module(usdz_module)
+
+def test_copy_materialx_files(tmp_path, monkeypatch):
+    cube = Path(__file__).resolve().parents[1] / 'cube.glb'
+    parser = usdz_module.Parser()
+    result = parser.parse([str(cube)])
+    assert result.inFilePath.endswith('cube.glb')
+
+    lib_dir = tmp_path / 'lib'
+    lib_dir.mkdir()
+    mtlx = lib_dir / 'test.mtlx'
+    mtlx.write_text('x')
+
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+
+    monkeypatch.setenv('MATERIALX_LIB_PATHS', str(lib_dir))
+
+    usdz_module.copyMaterialXLibraries(str(dest), False)
+    assert (dest / 'test.mtlx').exists()

--- a/usdzconvert/usdzconvert
+++ b/usdzconvert/usdzconvert
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3.7
+import os
 import os.path
 from os import chdir
 import sys
@@ -554,6 +555,22 @@ def copyMaterialTextures(params, material, srcPath, dstPath, folder):
             input.file = basename
 
 
+def copyMaterialXLibraries(folder, verbose=False):
+    paths = os.environ.get('MATERIALX_LIB_PATHS')
+    if not paths:
+        return
+    for path in paths.split(os.pathsep):
+        if not path:
+            continue
+        if not os.path.isdir(path):
+            continue
+        for filename in os.listdir(path):
+            if filename.endswith('.mtlx'):
+                src = os.path.join(path, filename)
+                dst = os.path.join(folder, filename)
+                usdUtils.copy(src, dst, verbose)
+
+
 def createStageMetadata(params):
     if params.creator != '':
         params.usdStage.SetMetadataByDictKey("customLayerData", "creator", str(params.creator))
@@ -784,6 +801,8 @@ def process(argumentList):
 
     if dstIsUsdz:
         # construct .usdz archive from the .usdc file
+        if parserOut.useMaterialX:
+            copyMaterialXLibraries(tmpFolder, parserOut.verbose)
         UsdUtils.CreateNewARKitUsdzPackage(Sdf.AssetPath(tmpPath), dstPath)
     else:
         usdUtils.copy(tmpPath, dstPath)


### PR DESCRIPTION
## Summary
- copy MaterialX `.mtlx` libraries when creating `.usdz` files
- document new packaging behaviour and update docs with line references
- test copying MaterialX libs using cube.glb

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd21962d48324a7b4227a4f0d1bcf