### PR TITLE
Fix MaterialX conversion with newer USD libraries

### DIFF
--- a/usdzconvert/usdStageWithGlTF.py
+++ b/usdzconvert/usdStageWithGlTF.py
@@ -1143,7 +1143,8 @@ class glTFConverter:
                     if count == 0: # no indices
                         count = accessor.count
             elif key == 'NORMAL':
-                normalPrimvar = usdGeom.CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.vertex)
+                api = UsdGeom.PrimvarsAPI(usdGeom)
+                normalPrimvar = api.CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.vertex)
                 normalPrimvar.Set(accessor.data)
             elif key == 'TANGENT':
                 pass
@@ -1161,7 +1162,8 @@ class glTFConverter:
 
                 texCoordSet = key[9:]
                 primvarName = 'st' if texCoordSet == '0' else 'st' + texCoordSet
-                uvs = usdGeom.CreatePrimvar(primvarName, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
+                api = UsdGeom.PrimvarsAPI(usdGeom)
+                uvs = api.CreatePrimvar(primvarName, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
                 uvs.Set(newData)
             elif key == 'COLOR_0':
                 data = accessor.data


### PR DESCRIPTION
## Summary
- update primvar creation to work with recent USD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0b46526c83249a34ade9f5ceb709