### PR TITLE
Fix PBR defaults and MaterialX input names

### DIFF
--- a/DOC_GLB_USDZ_MATERIALX_DETAIL_ZH.md
+++ b/DOC_GLB_USDZ_MATERIALX_DETAIL_ZH.md
@@ -21,6 +21,19 @@
 
 ## 4. 调整材质创建流程
 - `createMaterials()` 在生成 `usdUtils.Material` 后，根据 `self.useMaterialX` 选择调用 `makeUsdMaterialX()` 或 `makeUsdMaterial()`【F:usdzconvert/usdStageWithGlTF.py†L633-L720】。
-- 若启用 MaterialX，打包 `.usdz` 时应同时复制所需的 `.mtlx` 库文件，确保运行时可以解析【F:usdzconvert/usdzconvert†L802-L806】。
+ - 若启用 MaterialX，打包 `.usdz` 时应同时复制所需的 `.mtlx` 库文件，确保运行时可以解析【F:usdzconvert/usdzconvert†L802-L806】。
 
-通过以上修改，命令行添加 `-useMaterialX` 后即可在转换阶段生成基于 MaterialX 的 `UsdShade.Material` 网络，同时保持旧接口与 UsdPreviewSurface 的兼容。 
+通过以上修改，命令行添加 `-useMaterialX` 后即可在转换阶段生成基于 MaterialX 的 `UsdShade.Material` 网络，同时保持旧接口与 UsdPreviewSurface 的兼容。
+
+## 5. 参数映射
+生成 `standard_surface` 节点时，部分输入名称与 `UsdPreviewSurface` 不同，代码中进行了以下映射：
+
+| glTF 输入 | MaterialX 输入 |
+|-----------|----------------|
+| `diffuseColor` | `base_color` |
+| `metallic` | `metalness` |
+| `roughness` | `specular_roughness` |
+| `opacity` | `opacity` |
+| `emissiveColor` | `emission_color` |
+
+这样可确保与 glTF PBR 参数一致的数值在 MaterialX 网络中被正确解析。

--- a/DOC_USD_MATERIAL_CREATION_ZH.md
+++ b/DOC_USD_MATERIAL_CREATION_ZH.md
@@ -36,6 +36,8 @@ for gltfMaterial in self.gltf['materials'] if 'materials' in self.gltf else []:
 3. `_addMapToUsdMaterial()` 会按需生成 `UsdPrimvarReader_float2`、`UsdTransform2d` 和 `UsdUVTexture` 等节点，实现贴图文件、UV 变换和包裹模式的接入。
 4. `_makeTextureShaderNames()` 用于合并共享纹理文件，避免重复节点。
 
+从 0.3 版本起，即使 `metallic`、`roughness` 或 `opacity` 等值与默认值相同，也会显式写入 `UsdPreviewSurface` 输入，便于在后续流程中准确读取材质信息。
+
 以下代码展示了 `_makeUsdUVTexture()` 构建贴图节点的部分逻辑（位于 353-453 行）：
 ```python
 uvReader = UsdShade.Shader.Define(usdStage, uvReaderPath)

--- a/check_sphere_shader.py
+++ b/check_sphere_shader.py
@@ -40,7 +40,11 @@ def usd_shader_inputs(path, shader_id):
             if shader.GetIdAttr().Get() != shader_id:
                 continue
             result = {}
-            for name in ['diffuseColor', 'metallic', 'roughness', 'opacity', 'normal']:
+            if shader_id == 'ND_standard_surface_surfaceshader':
+                names = ['base_color', 'metalness', 'specular_roughness', 'opacity', 'normal']
+            else:
+                names = ['diffuseColor', 'metallic', 'roughness', 'opacity', 'normal']
+            for name in names:
                 inp = shader.GetInput(name)
                 if inp and inp.GetAttr().HasAuthoredValue():
                     result[name] = inp.GetAttr().Get()
@@ -76,7 +80,13 @@ def main():
     print('MaterialX shader inputs:', mtlx_inputs)
 
     check_material(expected, surface_inputs)
-    check_material(expected, mtlx_inputs)
+    mapped = {
+        'diffuseColor': mtlx_inputs.get('base_color'),
+        'metallic': mtlx_inputs.get('metalness'),
+        'roughness': mtlx_inputs.get('specular_roughness'),
+        'opacity': mtlx_inputs.get('opacity'),
+    }
+    check_material(expected, mapped)
     print('All checks passed.')
 
 

--- a/usdzconvert/usdStageWithGlTF.py
+++ b/usdzconvert/usdStageWithGlTF.py
@@ -664,6 +664,10 @@ class glTFConverter:
                     material.inputs[usdUtils.InputName.diffuseColor] = baseColorFactor
                     if isBlendOrMask:
                         material.inputs[usdUtils.InputName.opacity] = baseColorFactor[3]
+
+                # 始终记录不透明度，便于后续处理
+                if usdUtils.InputName.opacity not in material.inputs:
+                    material.inputs[usdUtils.InputName.opacity] = baseColorFactor[3]
                 
                 # metallic and roughness
                 roughnessFactor = pbr['roughnessFactor'] if 'roughnessFactor' in pbr else 1.0

--- a/usdzconvert/usdUtils.py
+++ b/usdzconvert/usdUtils.py
@@ -480,17 +480,10 @@ class Material:
             if InputName.normal == inputName and gfVec3d == Gf.Vec3d(0, 0, 1.0):
                 return True
         else:
-            if InputName.metallic == inputName and float(input) == 0.0:
-                return True
-            if InputName.roughness == inputName and float(input) == 0.5:
-                return True
+            # 保留金属度、粗糙度和透明度等数值，即便它们与默认值一致
             if InputName.clearcoat == inputName and float(input) == 0.0:
                 return True
             if InputName.clearcoatRoughness == inputName and float(input) == 0.01:
-                return True
-            if InputName.opacity == inputName and float(input) == 1.0:
-                return True
-            if InputName.occlusion == inputName and float(input) == 1.0:
                 return True
         return False
 
@@ -544,6 +537,14 @@ class Material:
 
         input = self.inputs[inputName]
         inputType = Input.types[inputIdx]
+        # MaterialX `standard_surface` 参数名称映射
+        mtlxName = {
+            InputName.diffuseColor: 'base_color',
+            InputName.metallic: 'metalness',
+            InputName.roughness: 'specular_roughness',
+            InputName.opacity: 'opacity',
+            InputName.emissiveColor: 'emission_color',
+        }.get(inputName, inputName)
 
         if isinstance(input, Map):
             map = input
@@ -551,12 +552,12 @@ class Material:
             channels = map.channels if len(map.channels) == len(defaultChannels) else defaultChannels
             matPath = str(surfaceShader.GetPath())
             textureShader = self._makeUsdUVTexture(matPath, map, inputName, channels, None, usdStage)
-            surfaceShader.CreateInput(inputName, inputType).ConnectToSource(textureShader.GetOutput(channels))
+            surfaceShader.CreateInput(mtlxName, inputType).ConnectToSource(textureShader.GetOutput(channels))
         elif isinstance(input, list):
             gfVec3d = Gf.Vec3d(float(input[0]), float(input[1]), float(input[2]))
-            surfaceShader.CreateInput(inputName, inputType).Set(gfVec3d)
+            surfaceShader.CreateInput(mtlxName, inputType).Set(gfVec3d)
         else:
-            surfaceShader.CreateInput(inputName, inputType).Set(float(input))
+            surfaceShader.CreateInput(mtlxName, inputType).Set(float(input))
 
 
 


### PR DESCRIPTION
## Summary
- preserve metallic/roughness/opacity even when default values
- map glTF parameters to MaterialX `standard_surface` inputs
- always record opacity from baseColorFactor
- document new MaterialX mapping and default value behaviour

## Testing
- `pytest -q`
- `python check_sphere_shader.py`

------
https://chatgpt.com/codex/tasks/task_e_684e170c12188324b97ab1ae70b85baa