### PR TITLE
Fix shader check script

### DIFF
--- a/check_sphere_shader.py
+++ b/check_sphere_shader.py
@@ -73,8 +73,9 @@ def main():
     expected = gltf_material_info(src)
     print('Expected material info:', expected)
 
-    surface = Path('sphere_surface.usdz')
-    mtlx = Path('sphere_mtlx.usdz')
+    # use .usdc to avoid ARKit validation during conversion
+    surface = Path('sphere_surface.usdc')
+    mtlx = Path('sphere_mtlx.usdc')
 
     convert(src, surface)
     convert(src, mtlx, True)


### PR DESCRIPTION
## Summary
- avoid ARKit validation when converting test sphere

## Testing
- `pip install usd-core numpy pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1f21a19483249db231ea392aeb37