### PR TITLE
Ignore shaderDefs warning in ARKit checker

### DIFF
--- a/DOC_LOCAL_SETUP_ZH.md
+++ b/DOC_LOCAL_SETUP_ZH.md
@@ -72,5 +72,8 @@ python samples/102_mesh.py
 如需自定义 MaterialX 库路径，可设置 `MATERIALX_LIB_PATHS` 环境变量，所有 `.mtlx` 文件
 会在转换时一并复制到输出包内。
 
+若运行 `usdzconvert` 时出现 `shaderDefs.usda` 相关警告，可忽略该信息，
+工具会继续生成 `.usdz` 文件并返回成功退出码。
+
 ---
 以上步骤即完成了本地环境搭建与测试流程。

--- a/tests/test_arkit_checker.py
+++ b/tests/test_arkit_checker.py
@@ -1,0 +1,40 @@
+import importlib.util
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+
+# stub modules for pxr
+pxr_stub = types.ModuleType('pxr')
+Tf = types.SimpleNamespace(ErrorException=Exception)
+
+class DummyChecker:
+    def __init__(self, *a, **k):
+        pass
+    def CheckCompliance(self, filename):
+        raise Tf.ErrorException("Could not find shader resource: shaderDefs.usda")
+    def GetErrors(self):
+        return []
+    def GetFailedChecks(self):
+        return []
+    _rules = []
+
+pxr_stub.UsdUtils = types.SimpleNamespace(ComplianceChecker=DummyChecker)
+pxr_stub.Tf = Tf
+sys.modules.setdefault('pxr', pxr_stub)
+
+# load usdARKitChecker script
+script_dir = Path(__file__).resolve().parents[1] / 'usdzconvert'
+sys.path.append(str(script_dir))
+script_path = script_dir / 'usdARKitChecker'
+loader = importlib.machinery.SourceFileLoader('usdARKitChecker_script', str(script_path))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+usd_checker_module = importlib.util.module_from_spec(spec)
+loader.exec_module(usd_checker_module)
+
+
+def test_missing_shaderdefs_warning():
+    errors = []
+    result = usd_checker_module.runValidators('dummy.usdz', False, errors)
+    assert result is True
+    assert errors == []

--- a/usdzconvert/usdARKitChecker
+++ b/usdzconvert/usdARKitChecker
@@ -25,6 +25,9 @@ def runValidators(filename, verboseOutput, errorData):
         checker.CheckCompliance(filename)
     except Tf.ErrorException as err:
         print("Warning: Failed to run USD compliance check:", err)
+        if "shaderDefs.usda" in str(err):
+            # Missing shader resources should not mark the whole check as failed
+            return True
         errorData.append({"code": "PXR_COMPLIANCE_CHECK_ERROR"})
         return False
 


### PR DESCRIPTION
## Summary
- allow usdARKitChecker to succeed when shaderDefs.usda is missing
- document warning handling in the local setup doc
- test that missing shaderDefs warning does not fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2045b0588324b9a1260e66a70505