### PR TITLE
Add GLB to GLTF export

### DIFF
--- a/check_sphere_shader.py
+++ b/check_sphere_shader.py
@@ -27,6 +27,12 @@ def convert(src, dst, use_mtlx=False):
     subprocess.check_call(cmd)
 
 
+def export_gltf(glb_path, out_path):
+    """Convert a GLB file to a JSON-based .gltf for inspection."""
+    gltf = GLTF2().load(str(glb_path))
+    gltf.save(str(out_path))
+
+
 def export_usda(usd_path, out_path):
     stage = Usd.Stage.Open(str(usd_path))
     stage.GetRootLayer().Export(str(out_path))
@@ -70,6 +76,8 @@ def check_material(expected, actual):
 
 def main():
     src = Path('glb_for_testing/sphere.glb')
+    # Also export a JSON-based glTF for easier inspection
+    export_gltf(src, src.with_suffix('.gltf'))
     expected = gltf_material_info(src)
     print('Expected material info:', expected)
 


### PR DESCRIPTION
## Summary
- allow inspecting `sphere.glb` as `sphere.gltf`
- convert the GLB into a `.gltf` file when running `check_sphere_shader.py`

## Testing
- `pip install usd-core numpy pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e249e966483249c45dbf13a80df39