### PR TITLE
Add KHR_materials_sheen support

### DIFF
--- a/DOC_USD_MATERIAL_CREATION_ZH.md
+++ b/DOC_USD_MATERIAL_CREATION_ZH.md
@@ -22,7 +22,7 @@ for gltfMaterial in self.gltf['materials'] if 'materials' in self.gltf else []:
 在该函数内部主要完成以下任务：
 1. 根据 `alphaMode` 设置 `opacity` 或 `opacityThreshold`。
 2. 读取 `pbrMetallicRoughness` 或 `KHR_materials_pbrSpecularGlossiness`，并通过 `processTexture()` 处理 `baseColorTexture`、`metallicRoughnessTexture` 等纹理。
-3. 解析扩展如 `KHR_materials_clearcoat`，填充 `clearcoat`、`clearcoatRoughness`。
+3. 解析扩展如 `KHR_materials_clearcoat`、`KHR_materials_sheen`，填充 `clearcoat`、`clearcoatRoughness`、`sheenColor`、`sheenRoughness`。
 4. 处理 `normalTexture`、`occlusionTexture`、`emissiveTexture` 等其它纹理和属性。
 
 `processTexture()` 会根据 uri 或 bufferView 保存贴图文件、设置包裹模式和 UV 变换，并将结果写入 `material.inputs`。

--- a/tests/test_materialx_generation.py
+++ b/tests/test_materialx_generation.py
@@ -20,6 +20,8 @@ class InputName:
     occlusion = 'occlusion'
     clearcoat = 'clearcoat'
     clearcoatRoughness = 'clearcoatRoughness'
+    sheenColor = 'sheenColor'
+    sheenRoughness = 'sheenRoughness'
 
 class NodeManager:
     def __init__(self):
@@ -28,9 +30,10 @@ class NodeManager:
 class Input:
     names = [InputName.normal, InputName.diffuseColor, InputName.opacity,
              InputName.emissiveColor, InputName.metallic, InputName.roughness,
-             InputName.occlusion, InputName.clearcoat, InputName.clearcoatRoughness]
-    channels = ['rgb','rgb','a','rgb','r','r','r','r','r']
-    types = [object]*9
+             InputName.occlusion, InputName.clearcoat, InputName.clearcoatRoughness,
+             InputName.sheenColor, InputName.sheenRoughness]
+    channels = ['rgb','rgb','a','rgb','r','r','r','r','r','rgb','r']
+    types = [object]*11
 
 class Material:
     def __init__(self, name):

--- a/usdzconvert/usdStageWithGlTF.py
+++ b/usdzconvert/usdStageWithGlTF.py
@@ -709,6 +709,15 @@ class glTFConverter:
                 if 'clearcoatRoughnessFactor' in clearcoatExt:
                     material.inputs[usdUtils.InputName.clearcoatRoughness] = clearcoatExt['clearcoatRoughnessFactor']
 
+            if 'extensions' in gltfMaterial and 'KHR_materials_sheen' in gltfMaterial['extensions']:
+                sheenExt = gltfMaterial['extensions']['KHR_materials_sheen']
+                if 'sheenColorFactor' in sheenExt:
+                    material.inputs[usdUtils.InputName.sheenColor] = sheenExt['sheenColorFactor']
+                if 'sheenRoughnessFactor' in sheenExt:
+                    material.inputs[usdUtils.InputName.sheenRoughness] = sheenExt['sheenRoughnessFactor']
+                self.processTexture(sheenExt, 'sheenColorTexture', usdUtils.InputName.sheenColor, 'rgb', material, sheenExt.get('sheenColorFactor'))
+                self.processTexture(sheenExt, 'sheenRoughnessTexture', usdUtils.InputName.sheenRoughness, 'a', material, sheenExt.get('sheenRoughnessFactor'))
+
             self.processTexture(gltfMaterial, 'normalTexture', usdUtils.InputName.normal, 'rgb', material)
             self.processTexture(gltfMaterial, 'occlusionTexture', usdUtils.InputName.occlusion, 'r', material) #TODO: add occlusion scale
 

--- a/usdzconvert/usdUtils.py
+++ b/usdzconvert/usdUtils.py
@@ -229,14 +229,21 @@ class InputName:
     occlusion = 'occlusion'
     clearcoat = 'clearcoat'
     clearcoatRoughness = 'clearcoatRoughness'
+    sheenColor = 'sheenColor'
+    sheenRoughness = 'sheenRoughness'
 
 
 
 class Input:
-    names = [InputName.normal, InputName.diffuseColor, InputName.opacity, InputName.emissiveColor, InputName.metallic, InputName.roughness, InputName.occlusion, InputName.clearcoat, InputName.clearcoatRoughness]
-    channels = ['rgb', 'rgb', 'a', 'rgb', 'r', 'r', 'r', 'r', 'r']
-    types = [Sdf.ValueTypeNames.Normal3f, Sdf.ValueTypeNames.Color3f, Sdf.ValueTypeNames.Float, 
-        Sdf.ValueTypeNames.Color3f, Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float]
+    names = [InputName.normal, InputName.diffuseColor, InputName.opacity,
+        InputName.emissiveColor, InputName.metallic, InputName.roughness,
+        InputName.occlusion, InputName.clearcoat, InputName.clearcoatRoughness,
+        InputName.sheenColor, InputName.sheenRoughness]
+    channels = ['rgb', 'rgb', 'a', 'rgb', 'r', 'r', 'r', 'r', 'r', 'rgb', 'r']
+    types = [Sdf.ValueTypeNames.Normal3f, Sdf.ValueTypeNames.Color3f, Sdf.ValueTypeNames.Float,
+        Sdf.ValueTypeNames.Color3f, Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float,
+        Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float, Sdf.ValueTypeNames.Float,
+        Sdf.ValueTypeNames.Color3f, Sdf.ValueTypeNames.Float]
 
 
 
@@ -479,11 +486,15 @@ class Material:
                 return True
             if InputName.normal == inputName and gfVec3d == Gf.Vec3d(0, 0, 1.0):
                 return True
+            if InputName.sheenColor == inputName and gfVec3d == Gf.Vec3d(0, 0, 0):
+                return True
         else:
             # 保留金属度、粗糙度和透明度等数值，即便它们与默认值一致
             if InputName.clearcoat == inputName and float(input) == 0.0:
                 return True
             if InputName.clearcoatRoughness == inputName and float(input) == 0.01:
+                return True
+            if InputName.sheenRoughness == inputName and float(input) == 0.0:
                 return True
         return False
 
@@ -544,6 +555,8 @@ class Material:
             InputName.roughness: 'specular_roughness',
             InputName.opacity: 'opacity',
             InputName.emissiveColor: 'emission_color',
+            InputName.sheenColor: 'sheen_color',
+            InputName.sheenRoughness: 'sheen_roughness',
         }.get(inputName, inputName)
 
         if isinstance(input, Map):


### PR DESCRIPTION
## Summary
- handle `KHR_materials_sheen` extension when creating materials
- expose new `sheenColor` and `sheenRoughness` inputs
- map sheen parameters when generating MaterialX
- update Chinese documentation
- extend tests stubs for new material inputs

## Testing
- `pip install usd-core numpy pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e27d719848324b72b76687da371a5